### PR TITLE
feat: add boot server agent with self-healing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.2.0] - 2024-06-10
+### Added
+- BootServerAgent with HTTP and TFTP services and self-healing support.
+
 ## [0.1.0] - 2024-06-04
 ### Added
 - Initial project scaffolding with agent-based architecture.

--- a/PROBLEMS.md
+++ b/PROBLEMS.md
@@ -1,3 +1,3 @@
 # Problems Log
 
-- Initial scaffolding provides only network detection and documentation agents. Boot server functionality (DHCP/TFTP/HTTP) and self-healing features remain TODO.
+- DHCP service integration and advanced self-healing logic are still pending.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Netboot Snooter
 
-A modular, agent-driven toolkit for building a self-documenting netboot server. The system is under active development and currently focuses on collecting host network information.
+A modular, agent-driven toolkit for building a self-documenting netboot server. The system is under active development and currently focuses on collecting host network information and hosting boot files.
 
 ## Usage
 ```
@@ -9,6 +9,7 @@ python -m netboot.main
 Generated files:
 - `vars.txt`: Detected network variables.
 - `client.txt`: Information for netboot clients (stub).
+- HTTP and TFTP services serve files from `boot/`.
 
 Logs are stored in `logs/`.
 

--- a/netboot/agents/boot_server.py
+++ b/netboot/agents/boot_server.py
@@ -1,0 +1,113 @@
+"""Boot server agent providing HTTP and TFTP services."""
+from __future__ import annotations
+
+import logging
+from functools import partial
+from pathlib import Path
+from threading import Thread
+from typing import Optional
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+
+try:
+    from tftpy import TftpServer
+except Exception:  # pragma: no cover - tftpy may be missing
+    TftpServer = None  # type: ignore[assignment]
+
+
+class BootServerAgent:
+    """Start minimal HTTP and TFTP services and keep them running."""
+
+    def __init__(
+        self,
+        root: Path | str = Path("boot"),
+        http_port: int = 8000,
+        tftp_port: int = 6969,
+    ) -> None:
+        self.root = Path(root)
+        self.root.mkdir(exist_ok=True)
+        self.http_port = http_port
+        self.tftp_port = tftp_port
+        self.logger = logging.getLogger(self.__class__.__name__)
+        self.http_server: Optional[ThreadingHTTPServer] = None
+        self.http_thread: Optional[Thread] = None
+        self.tftp_server: Optional[TftpServer] = None
+        self.tftp_thread: Optional[Thread] = None
+
+    # ------------------------------------------------------------------
+    # HTTP handling
+    def start_http(self, port: Optional[int] = None) -> int:
+        """Start an HTTP server serving files from ``root``.
+
+        Returns the port the server is bound to.
+        """
+        if port is not None:
+            self.http_port = port
+        handler = partial(SimpleHTTPRequestHandler, directory=str(self.root))
+        self.http_server = ThreadingHTTPServer(("0.0.0.0", self.http_port), handler)
+        # If port 0 was given, update to actual port
+        self.http_port = self.http_server.server_address[1]
+        self.http_thread = Thread(target=self.http_server.serve_forever, daemon=True)
+        self.http_thread.start()
+        self.logger.info("HTTP server started on port %s", self.http_port)
+        return self.http_port
+
+    def stop_http(self) -> None:
+        if self.http_server:
+            self.http_server.shutdown()
+            self.http_server.server_close()
+            if self.http_thread:
+                self.http_thread.join()
+            self.http_server = None
+            self.http_thread = None
+
+    # ------------------------------------------------------------------
+    # TFTP handling
+    def start_tftp(self, port: Optional[int] = None) -> Optional[int]:
+        """Start a TFTP server if :mod:`tftpy` is available."""
+        if TftpServer is None:
+            self.logger.warning("tftpy not installed; skipping TFTP server")
+            return None
+        if port is not None:
+            self.tftp_port = port
+        self.tftp_server = TftpServer(str(self.root))
+        self.tftp_thread = Thread(
+            target=self.tftp_server.listen,
+            kwargs={"listenip": "0.0.0.0", "listenport": self.tftp_port},
+            daemon=True,
+        )
+        self.tftp_thread.start()
+        self.logger.info("TFTP server started on port %s", self.tftp_port)
+        return self.tftp_port
+
+    def stop_tftp(self) -> None:
+        if self.tftp_server:
+            self.tftp_server.stop(now=True)
+            if self.tftp_thread:
+                self.tftp_thread.join()
+            self.tftp_server = None
+            self.tftp_thread = None
+
+    # ------------------------------------------------------------------
+    def ensure_running(self) -> None:
+        """Restart any service that has stopped."""
+        if self.http_server is None or self.http_thread is None or not self.http_thread.is_alive():
+            self.logger.warning("HTTP server not running; restarting")
+            self.start_http(self.http_port)
+        if TftpServer is not None and (
+            self.tftp_server is None or self.tftp_thread is None or not self.tftp_thread.is_alive()
+        ):
+            self.logger.warning("TFTP server not running; restarting")
+            self.start_tftp(self.tftp_port)
+
+    def run(self) -> None:
+        """Start all services."""
+        self.start_http(self.http_port)
+        self.start_tftp(self.tftp_port)
+
+    def stop(self) -> None:
+        """Stop all running services."""
+        self.stop_http()
+        self.stop_tftp()
+
+
+__all__ = ["BootServerAgent"]

--- a/netboot/main.py
+++ b/netboot/main.py
@@ -2,10 +2,12 @@
 from __future__ import annotations
 
 import logging
+import time
 from pathlib import Path
 
 from .agents.network import NetworkScrapeAgent
 from .agents.doc_agent import DocAgent
+from .agents.boot_server import BootServerAgent
 
 LOG_DIR = Path("logs")
 LOG_DIR.mkdir(exist_ok=True)
@@ -26,6 +28,15 @@ def main() -> None:
 
     doc_agent = DocAgent()
     doc_agent.run()
+
+    boot_agent = BootServerAgent()
+    boot_agent.run()
+    try:
+        while True:
+            time.sleep(60)
+            boot_agent.ensure_running()
+    except KeyboardInterrupt:
+        boot_agent.stop()
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 netifaces
 pytest
+tftpy

--- a/tests/test_boot_server_agent.py
+++ b/tests/test_boot_server_agent.py
@@ -1,0 +1,22 @@
+import time
+import urllib.request
+from pathlib import Path
+
+from netboot.agents.boot_server import BootServerAgent
+
+
+def test_http_server_serves_file_and_self_heals(tmp_path: Path):
+    root = tmp_path / "root"
+    root.mkdir()
+    (root / "index.txt").write_text("hello")
+    agent = BootServerAgent(root=root, http_port=0, tftp_port=0)
+    port = agent.start_http()
+    # allow server to start
+    time.sleep(0.1)
+    data = urllib.request.urlopen(f"http://127.0.0.1:{port}/index.txt").read().decode()
+    assert data == "hello"
+    agent.stop_http()
+    assert agent.http_thread is None or not agent.http_thread.is_alive()
+    agent.ensure_running()
+    assert agent.http_thread is not None and agent.http_thread.is_alive()
+    agent.stop()


### PR DESCRIPTION
## Summary
- introduce BootServerAgent to serve boot files over HTTP and TFTP with simple restart logic
- wire BootServerAgent into main entry point and document boot file hosting
- add regression test for HTTP serving and self-healing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689417df56f4833299d1ea7d86ed0c6b